### PR TITLE
Add Docker Compose setup with hot reload and rewrite README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,87 @@
-# React + Vite
+# Botanica
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Botanica is a plant care app built on the belief that anyone can have a green thumb — even the most notorious plant killers. It takes the guesswork out of plant care by giving you everything you need to keep your plants alive and thriving: browse plants, learn their care requirements, and build a personal garden you can actually manage. Whether you've never kept a plant alive or you're looking to grow your collection, Botanica makes it easy.
 
-Currently, two official plugins are available:
+## Tech stack
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- **Frontend:** React 18, Vite, Redux, React Router 7, React Hook Form, Bootstrap 5, Axios
+- **Backend:** Node.js, Express, Mongoose
+- **Database:** MongoDB
+- **Auth:** JWT stored in httpOnly cookies
 
+## Project structure
+
+The repo has two top-level directories — `backend/` and `frontend/` — plus a `docker-compose.yml` at the root that wires them together with a MongoDB instance.
+
+```
+backend/                    Entry point: server.js
+├── routes/
+├── controllers/
+├── models/                 # Mongoose models
+└── middleware/auth.js      # JWT auth middleware
+
+frontend/src/               Entry point: main.jsx
+├── pages/
+├── components/
+├── services/               # Axios API calls
+└── store/                  # Redux global state
+```
+
+## Running with Docker (recommended)
+
+Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/).
+
+```bash
+docker compose up --build   # first run
+docker compose up           # subsequent runs
+```
+
+| Service  | URL                    |
+|----------|------------------------|
+| Frontend | http://localhost:5173  |
+| Backend  | http://localhost:5001  |
+| MongoDB  | localhost:27017        |
+
+Source files are mounted as volumes — saving any file triggers hot reload automatically without rebuilding.
+
+Use `--build` again after installing new npm packages or changing a `Dockerfile`.
+
+## Running without Docker
+
+**Prerequisites:** Node.js 22+, MongoDB running locally on port 27017.
+
+```bash
+# Terminal 1 — backend
+cd backend
+cp .env.example .env      # then fill in JWT_SECRET
+npm install
+npm run dev
+
+# Terminal 2 — frontend
+cd frontend
+npm install
+npm run dev
+```
+
+## Environment variables
+
+Copy `backend/.env.example` to `backend/.env` and set the following:
+
+| Variable      | Default                                  | Description              |
+|---------------|------------------------------------------|--------------------------|
+| `PORT`        | `5001`                                   | Backend port             |
+| `MONGO_URI`   | `mongodb://127.0.0.1:27017/BotanicaDB`   | MongoDB connection string |
+| `JWT_SECRET`  | —                                        | Secret for signing JWTs  |
+| `CORS_ORIGIN` | `http://localhost:5173`                  | Allowed frontend origin  |
+
+Docker Compose overrides `MONGO_URI` automatically to use the `mongo` service name.
+
+## API routes
+
+| Method | Path                    | Auth | Description          |
+|--------|-------------------------|------|----------------------|
+| POST   | `/api/users/signup`     |      | Register             |
+| POST   | `/api/users/login`      |      | Login                |
+| GET    | `/api/users/auth/me`    | JWT  | Get current user     |
+| GET    | `/api/plants`           |      | List plants (paginated, filterable) |
+| GET    | `/api/plants/:id`       |      | Get plant by ID      |

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5001
+CMD ["npm", "run", "dev"]

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,8 @@
   "description": "Plant management application",
   "main": "server.js",
   "scripts": {
+    "dev": "node --watch server.js",
+    "start": "node server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Sofia Schwartz",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  mongo:
+    image: mongo:7
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+  backend:
+    build: ./backend
+    ports:
+      - "5001:5001"
+    env_file:
+      - ./backend/.env          # loads JWT_SECRET and other secrets
+    environment:
+      - MONGO_URI=mongodb://mongo:27017/BotanicaDB   # override .env — uses Docker service name
+      - CORS_ORIGIN=http://localhost:5173
+    volumes:
+      - ./backend:/app
+      - /app/node_modules
+    depends_on:
+      - mongo
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "5173:5173"
+    volumes:
+      - ./frontend:/app
+      - /app/node_modules
+    depends_on:
+      - backend
+
+volumes:
+  mongo_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY . .
+EXPOSE 5173
+CMD ["npm", "run", "dev", "--", "--host"]

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    host: true,
+    hmr: { host: 'localhost' },
+    watch: { usePolling: true },
+  },
 })


### PR DESCRIPTION
- Adds `Dockerfiles`, `.dockerignore` files, and a `docker-compose.yml` that runs MongoDB, Express, and Vite together via `docker compose up`.
- Volume mounts and file watching enable hot reload without rebuilding.
- `node_modules` are kept in the container using an anonymous volume. This prevents the host folder from overwriting it and avoids dependency conflicts between the host and container OS.
- Updates `vite.config.js` to expose the dev server on `0.0.0.0`, making the frontend reachable from outside the container.
- MongoDB data is persisted via a named volume so the database survives container restarts.
- `README` now documents project description, structure, setup instructions, environment variables, and API routes.